### PR TITLE
Add endpoints for local photo registration and Azure upload

### DIFF
--- a/FormAI.Api/FormAI.Api/Controllers/PhotoDtos.cs
+++ b/FormAI.Api/FormAI.Api/Controllers/PhotoDtos.cs
@@ -1,0 +1,26 @@
+namespace FormAI.Api.Controllers;
+
+// Request DTO for scanning directories for photos
+public sealed class PhotoScanRequestDto
+{
+    public required string RootPath { get; init; }
+}
+
+// Response DTO for scan operation
+public sealed class PhotoScanResponseDto
+{
+    public PhotoScanResponseDto(int addedCount) => AddedCount = addedCount;
+    public int AddedCount { get; }
+}
+
+// Request DTO for uploading pending photos
+public sealed class PhotoUploadRequestDto
+{
+}
+
+// Response DTO for upload operation
+public sealed class PhotoUploadResponseDto
+{
+    public PhotoUploadResponseDto(int uploadedCount) => UploadedCount = uploadedCount;
+    public int UploadedCount { get; }
+}

--- a/FormAI.Api/FormAI.Api/Controllers/PhotosController.cs
+++ b/FormAI.Api/FormAI.Api/Controllers/PhotosController.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using FormAI.Api.Controllers; // DTOs
+using FormAI.Api.Data;
+using FormAI.Api.Models;
+using FormAI.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace FormAI.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PhotosController : ControllerBase
+{
+    private readonly AppDbContext _context;
+    private readonly AzureBlobStorageService _storageService;
+
+    public PhotosController(AppDbContext context, AzureBlobStorageService storageService)
+    {
+        _context = context;
+        _storageService = storageService;
+    }
+
+    [HttpPost("scan")]
+    public async Task<ActionResult<PhotoScanResponseDto>> Scan([FromBody] PhotoScanRequestDto request)
+    {
+        // Endpoint to scan directory and register photos
+        var files = Directory.EnumerateFiles(request.RootPath, "*.jpg", SearchOption.AllDirectories);
+        var added = 0;
+        foreach (var file in files)
+        {
+            if (!await _context.Photos.AnyAsync(p => p.LocalPath == file))
+            {
+                _context.Photos.Add(new Photo { LocalPath = file });
+                added++;
+            }
+        }
+        await _context.SaveChangesAsync();
+        return Ok(new PhotoScanResponseDto(added));
+    }
+
+    [HttpPost("upload")]
+    public async Task<ActionResult<PhotoUploadResponseDto>> Upload([FromBody] PhotoUploadRequestDto request)
+    {
+        // Endpoint to upload pending photos to Azure Storage
+        var photos = await _context.Photos.Where(p => !p.Uploaded).ToListAsync();
+        var uploaded = 0;
+        foreach (var photo in photos)
+        {
+            var storageUrl = await _storageService.UploadAsync(photo.LocalPath);
+            photo.StorageUrl = storageUrl;
+            photo.Uploaded = true;
+            uploaded++;
+        }
+        await _context.SaveChangesAsync();
+        return Ok(new PhotoUploadResponseDto(uploaded));
+    }
+}

--- a/FormAI.Api/FormAI.Api/FormAI.Api.csproj
+++ b/FormAI.Api/FormAI.Api/FormAI.Api.csproj
@@ -18,10 +18,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Controllers\" />
+    <Folder Include="Services\" />
   </ItemGroup>
 
 </Project>

--- a/FormAI.Api/FormAI.Api/Models/Photo.cs
+++ b/FormAI.Api/FormAI.Api/Models/Photo.cs
@@ -2,5 +2,12 @@ namespace FormAI.Api.Models;
 
 public class Photo : ModelBase
 {
-    public required string Url { get; set; }
+    // Full path to the photo on disk
+    public required string LocalPath { get; set; }
+
+    // Indicates whether the photo has been uploaded to storage
+    public bool Uploaded { get; set; }
+
+    // Reference to the uploaded file in Azure Storage
+    public string? StorageUrl { get; set; }
 }

--- a/FormAI.Api/FormAI.Api/Program.cs
+++ b/FormAI.Api/FormAI.Api/Program.cs
@@ -1,4 +1,5 @@
 using FormAI.Api.Data;
+using FormAI.Api.Services;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +16,9 @@ builder.Services.AddOpenApi();
 
 // Configure Entity Framework Core to use SQL Server
 builder.Services.AddDbContext<AppDbContext>();
+
+// Service responsible for communication with Azure Blob Storage
+builder.Services.AddSingleton<AzureBlobStorageService>();
 
 var app = builder.Build();
 

--- a/FormAI.Api/FormAI.Api/Services/AzureBlobStorageService.cs
+++ b/FormAI.Api/FormAI.Api/Services/AzureBlobStorageService.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
+
+namespace FormAI.Api.Services;
+
+// Service for interacting with Azure Blob Storage
+public class AzureBlobStorageService
+{
+    private readonly BlobContainerClient _containerClient;
+
+    public AzureBlobStorageService(IConfiguration configuration)
+    {
+        // Container client is initialized once using the provided connection string
+        var connectionString = configuration.GetConnectionString("AzureStorage") ?? throw new InvalidOperationException("Storage connection string not configured");
+        var blobServiceClient = new BlobServiceClient(connectionString);
+        _containerClient = blobServiceClient.GetBlobContainerClient("originals");
+        _containerClient.CreateIfNotExists();
+    }
+
+    // Uploads a file to the Originals container and returns the blob URL
+    public async Task<string> UploadAsync(string localPath, CancellationToken cancellationToken = default)
+    {
+        var fileName = Path.GetFileName(localPath);
+        var blobClient = _containerClient.GetBlobClient(fileName);
+        await using var stream = File.OpenRead(localPath);
+        await blobClient.UploadAsync(stream, overwrite: true, cancellationToken);
+        return blobClient.Uri.ToString();
+    }
+}

--- a/FormAI.Api/FormAI.Api/appsettings.Development.json
+++ b/FormAI.Api/FormAI.Api/appsettings.Development.json
@@ -6,6 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=tcp:YOUR_SERVER.database.windows.net,1433;Initial Catalog=YOUR_DB;Persist Security Info=False;User ID=YOUR_USER;Password=YOUR_PASSWORD;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "DefaultConnection": "Server=tcp:YOUR_SERVER.database.windows.net,1433;Initial Catalog=YOUR_DB;Persist Security Info=False;User ID=YOUR_USER;Password=YOUR_PASSWORD;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+    "AzureStorage": "UseDevelopmentStorage=true"
   }
 }

--- a/FormAI.Api/FormAI.Api/appsettings.json
+++ b/FormAI.Api/FormAI.Api/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "AzureStorage": "UseDevelopmentStorage=true"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- add service and endpoints to scan directories for JPG photos and upload pending files to Azure storage
- store local paths, upload flag, and storage URL in Photo model
- wire Azure storage service and connection string
- remove generated migration files to keep repository migration-free

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1861b15d08325bd27a32a5da9d34e